### PR TITLE
Switch to gophercloud/gophercloud

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -37,8 +37,7 @@ import (
 
 	"github.com/monasca/golang-monascaclient/monascaclient"
 	"github.com/monasca/golang-monascaclient/monascaclient/models"
-	"github.com/rackspace/gophercloud"
-	"github.com/rackspace/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack"
 )
 
 // TODO: support for multiple namespaces
@@ -58,11 +57,6 @@ var (
 	kubePort         = flag.String("port", getEnvDefault("KUBERNETES_SERVICE_PORT_HTTPS", "443"), "The port of the Kubernetes API server")
 	monServer        = flag.String("monasca", "http://monasca-api:8070/v2.0", "The URI of the monasca api")
 	namespace        = flag.String("namespace", getEnvDefault("NAMESPACE", "default"), "The namespace to use.")
-	keystoneServer   = flag.String("keystone", getEnvDefault("OS_AUTH_URL", "http://monasca-keystone:35357/v3"), "The url of the keystone server")
-	keystoneUser     = flag.String("keystone-user", getEnvDefault("OS_USERNAME", "mini-mon"), "The keystone user")
-	keystonePassword = flag.String("keystone-pass", getEnvDefault("OS_PASSWORD", "mini-mon"), "The keystone password")
-	keystoneDomain   = flag.String("keystone-domain", getEnvDefault("OS_DOMAIN_NAME", "default"), "The keystone domain")
-	keystoneProject  = flag.String("keystone-project", getEnvDefault("OS_PROJECT_NAME", "mini-mon"), "The keystone project")
 
 	token      string
 	httpClient *http.Client
@@ -181,13 +175,11 @@ outer:
 }
 
 func set_keystone_token() error {
-	opts := gophercloud.AuthOptions{
-		IdentityEndpoint: *keystoneServer,
-		Username:         *keystoneUser,
-		Password:         *keystonePassword,
-		DomainName:       *keystoneDomain,
-		TenantName:       *keystoneProject,
-	}
+	opts, err := openstack.AuthOptionsFromEnv()
+  if err != nil {
+  	log.Print(err)
+  	return err
+  }
 
 	openstackProvider, err := openstack.AuthenticatedClient(opts)
 	if err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d6d7035ff5757536f33e166ce4eb1d0b148ad33de0c2ddfb63b983bab8e14a99
-updated: 2017-10-13T14:03:09.537728347-06:00
+hash: 576760ebb9c1b2be70655ca6594a320e3047c39fc4c6ed81791061e86d35488a
+updated: 2017-10-18T14:37:30.579699953-06:00
 imports:
 - name: ""
   version: c3adf7f4ac1a924c5d32fe81b904d86a90658fc4
@@ -7,6 +7,10 @@ imports:
   subpackages:
   - monascaclient
   - monascaclient/models
+- name: github.com/gophercloud/gophercloud
+  version: 443743e88335413103dcf1997e46d401b264fbcd
+  subpackages:
+  - openstack
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/monasca/golang-monascaclient

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,6 @@ import:
   subpackages:
   - monascaclient
   - monascaclient/models
-- package: github.com/rackspace/gophercloud
-  version: ^1.0.0
+- package: github.com/gophercloud/gophercloud
   subpackages:
   - openstack


### PR DESCRIPTION
rackspace/gophercloud only seems to support keystone v2, but
confusingly we use OS_PROJECT_NAME and then map it to OS_TENANT_NAME
internally.

Instead, we can just use gophercloud's new AuthOptionsFromEnv()
function, which means we don't need to handle auth arguments at all,
and it will properly handle keystone v3 parameters.